### PR TITLE
Enable Arithmetic Encoding/Decoding

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,14 +32,15 @@ endif
 
 
 libjpeg_turbo_common_src_files := \
-    jcapimin.c jcapistd.c jccoefct.c jccolor.c jcdctmgr.c jchuff.c \
-    jcinit.c jcmainct.c jcmarker.c jcmaster.c jcomapi.c jcparam.c \
-    jcphuff.c jcprepct.c jcsample.c jctrans.c jdapimin.c jdapistd.c \
-    jdatadst.c jdatasrc.c jdcoefct.c  jdcolor.c jddctmgr.c jdhuff.c \
-    jdinput.c jdmainct.c jdmarker.c jdmaster.c jdmerge.c jdphuff.c \
-    jdpostct.c jdsample.c jdtrans.c jerror.c jfdctflt.c jfdctfst.c \
-    jfdctint.c jidctflt.c jidctfst.c jidctint.c jidctred.c jmemmgr.c \
-    jmemnobs.c jquant1.c jquant2.c jutils.c
+    jcapimin.c jcapistd.c jaricom.c jcarith.c jccoefct.c jccolor.c \
+    jcdctmgr.c jchuff.c jcinit.c jcmainct.c jcmarker.c jcmaster.c \
+    jcomapi.c  jcparam.c jcphuff.c jcprepct.c jcsample.c jctrans.c \
+    jdapimin.c  jdapistd.c jdarith.c jdatadst.c jdatasrc.c jdcoefct.c \
+    jdcolor.c jddctmgr.c jdhuff.c jdinput.c jdmainct.c jdmarker.c \
+    jdmaster.c jdmerge.c jdphuff.c  jdpostct.c jdsample.c jdtrans.c \
+    jerror.c jfdctflt.c jfdctfst.c jfdctint.c jidctflt.c jidctfst.c \
+    jidctint.c jidctred.c jmemmgr.c jmemnobs.c jquant1.c jquant2.c \
+    jutils.c
 
 # ARM v7 NEON
 libjpeg_turbo_common_src_files_arm := simd/jsimd_arm_neon.S simd/jsimd_arm.c

--- a/jconfig.h
+++ b/jconfig.h
@@ -11,10 +11,10 @@
 #define LIBJPEG_TURBO_VERSION_NUMBER 1005001
 
 /* Support arithmetic encoding */
-/* #undef C_ARITH_CODING_SUPPORTED */
+#define C_ARITH_CODING_SUPPORTED 1
 
 /* Support arithmetic decoding */
-/* #undef  D_ARITH_CODING_SUPPORTED */
+#define D_ARITH_CODING_SUPPORTED 1
 
 /*
  * Define BITS_IN_JSAMPLE as either


### PR DESCRIPTION
This commit adds the needed files for the
Arithmetic Encoder/Decoder to compilation
and enables Arithmetic Encoding/Decoding support
in the proper configuration file.

Test: Displaying appropriate JPEG files.

Change-Id: I1745464a9af46ac8abfe6722f666589cb82ef59d
Signed-off-by: Alex Naidis <alex.naidis@linux.com>